### PR TITLE
Finish before overriding pending transitions.

### DIFF
--- a/library/src/main/java/com/vanniktech/rxpermission/ShadowActivity.java
+++ b/library/src/main/java/com/vanniktech/rxpermission/ShadowActivity.java
@@ -53,9 +53,9 @@ import static android.os.Build.VERSION_CODES.M;
   }
 
   @Override public void finish() {
+    super.finish();
     // Reset the animation to avoid flickering.
     overridePendingTransition(0, 0);
-    super.finish();
   }
 
   @Override protected void onSaveInstanceState(final Bundle outState) {


### PR DESCRIPTION
Otherwise there is no pending transition yet, and it flickers.